### PR TITLE
Bugfix/version number

### DIFF
--- a/files/opt/tomcat/lib/org/apache/catalina/util/ServerInfo.properties
+++ b/files/opt/tomcat/lib/org/apache/catalina/util/ServerInfo.properties
@@ -1,0 +1,1 @@
+server.info=Apache Tomcat

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,1 +1,3 @@
 ---
+- name: restart tomcat
+  service: name=tomcat state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,9 +42,19 @@
     dest: /etc/saxon-license.lic
     mode: "0644"
 
-- name: copy fgdc2iso app
+- name: Create lib path for serverinfo.properties
+  file:
+    path: /opt/tomcat/lib/org/apache/catalina/util
+    state: directory
+    owner: tomcat
+    group: tomcat
+    mode: 0750
+
+- name: copy serverinfo.properties
   copy:
     src: opt/tomcat/lib/org/apache/catalina/util/ServerInfo.properties
     dest: /opt/tomcat/lib/org/apache/catalina/util/ServerInfo.properties
-    mode: 0644
+    owner: tomcat
+    group: tomcat
+    mode: 0640
   notify: restart tomcat

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,4 +58,3 @@
     group: tomcat
     mode: 0640
   notify: restart tomcat
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,3 +58,4 @@
     group: tomcat
     mode: 0640
   notify: restart tomcat
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,3 +41,10 @@
       {{ fgdc2iso_saxon_license }}
     dest: /etc/saxon-license.lic
     mode: "0644"
+
+- name: copy fgdc2iso app
+  copy:
+    src: opt/tomcat/lib/org/apache/catalina/util/ServerInfo.properties
+    dest: /opt/tomcat/lib/org/apache/catalina/util/ServerInfo.properties
+    mode: 0644
+  notify: restart tomcat


### PR DESCRIPTION
Added to the playbook to put in steps to create directories in the /opt/tomcat/lib to hold the ServerInfo.properties and set server.info to not show the tomcat version.